### PR TITLE
Extract SQLite into adapter

### DIFF
--- a/lib/active_record/tenanted.rb
+++ b/lib/active_record/tenanted.rb
@@ -4,6 +4,9 @@ require "active_record"
 
 require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem_extension(ActiveRecord)
+loader.inflector.inflect(
+  "sqlite" => "SQLite",
+)
 loader.setup
 
 module ActiveRecord

--- a/lib/active_record/tenanted/database_adapter.rb
+++ b/lib/active_record/tenanted/database_adapter.rb
@@ -34,7 +34,7 @@ module ActiveRecord
               yield
             end
           else
-            identifier = config_or_identifier
+            identifier = db_config_or_identifier
             ActiveRecord::Tenanted::DatabaseAdapters::SQLite.acquire_lock(identifier, &block)
           end
         end

--- a/lib/active_record/tenanted/database_adapter.rb
+++ b/lib/active_record/tenanted/database_adapter.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    class DatabaseAdapter
+      ADAPTERS = {
+        "sqlite3" => "ActiveRecord::Tenanted::DatabaseAdapters::SQLite",
+      }.freeze
+
+      class << self
+        def create_database(db_config)
+          adapter_for(db_config).create_database
+        end
+
+        def drop_database(db_config)
+          adapter_for(db_config).drop_database
+        end
+
+        def database_exists?(db_config)
+          adapter_for(db_config).database_exists?
+        end
+
+        def acquire_lock(db_config_or_identifier, lock_name = nil, &block)
+          # Handle both new signature (config, lock_name) and legacy (identifier)
+          if db_config_or_identifier.respond_to?(:adapter)
+            config = db_config_or_identifier
+            adapter_name = config.adapter || config.configuration_hash[:adapter]
+
+            if adapter_name == "sqlite3"
+              identifier = lock_name || "tenant_creation_#{config.database}"
+              adapter_for(config).acquire_lock(identifier, &block)
+            else
+              # MySQL and other databases don't need locking - just execute the block
+              yield
+            end
+          else
+            identifier = config_or_identifier
+            ActiveRecord::Tenanted::DatabaseAdapters::SQLite.acquire_lock(identifier, &block)
+          end
+        end
+
+        def list_tenant_databases(db_config)
+          adapter_for(db_config).list_tenant_databases
+        end
+
+        def validate_tenant_name(db_config, tenant_name)
+          adapter_for(db_config).validate_tenant_name(tenant_name)
+        end
+
+        def adapter_for(db_config, *arguments)
+          adapter_name = db_config.adapter || db_config.configuration_hash[:adapter]
+          adapter_class_name = ADAPTERS[adapter_name]
+
+          if adapter_class_name.nil?
+            raise ActiveRecord::Tenanted::Error,
+                  "Unsupported database adapter for tenanting: #{adapter_name}. " \
+                  "Supported adapters: #{ADAPTERS.keys.join(', ')}"
+          end
+
+          adapter_class_name.constantize.new(db_config, *arguments)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/tenanted/database_adapters/sqlite.rb
+++ b/lib/active_record/tenanted/database_adapters/sqlite.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    module DatabaseAdapters
+      class SQLite
+        def initialize(db_config)
+          @db_config = db_config
+          @configuration_hash = db_config.configuration_hash
+        end
+
+        def create_database
+          database_path = get_database_path(db_config)
+
+          # Ensure the directory exists
+          database_dir = File.dirname(database_path)
+          FileUtils.mkdir_p(database_dir) unless File.directory?(database_dir)
+
+          # Create the SQLite database file
+          FileUtils.touch(database_path)
+        end
+
+        def drop_database
+          database_path = get_database_path(db_config)
+
+          # Remove the SQLite database file and associated files
+          FileUtils.rm_f(database_path)
+          FileUtils.rm_f("#{database_path}-wal")  # Write-Ahead Logging file
+          FileUtils.rm_f("#{database_path}-shm")  # Shared Memory file
+        end
+
+        def database_exists?
+          database_path = get_database_path(db_config)
+          File.exist?(database_path) && !ActiveRecord::Tenanted::Mutex::Ready.locked?(database_path)
+        end
+
+        def list_tenant_databases
+          glob = db_config.database_path_for("*")
+          scanner = Regexp.new(db_config.database_path_for("(.+)"))
+
+          Dir.glob(glob).filter_map do |path|
+            result = path.scan(scanner).flatten.first
+            if result.nil?
+              Rails.logger.warn "ActiveRecord::Tenanted: Cannot parse tenant name from filename #{path.inspect}"
+            end
+            result
+          end
+        end
+
+        def acquire_lock(lock_identifier, timeout: 10, &block)
+          # Use file-based locking for SQLite
+          ActiveRecord::Tenanted::Mutex::Ready.lock(lock_identifier, &block)
+        end
+
+        def validate_tenant_name(tenant_name)
+          if tenant_name.match?(%r{[/'"`]})
+            raise BadTenantNameError, "Tenant name contains an invalid character: #{tenant_name.inspect}"
+          end
+        end
+
+        def coerce_database_path(database_string)
+          # Handle SQLite URI formats
+          # See https://sqlite.org/uri.html
+          if database_string.start_with?("file:/")
+            URI.parse(database_string).path
+          elsif database_string.start_with?("file:")
+            URI.parse(database_string.sub(/\?.*$/, "")).opaque
+          else
+            database_string
+          end
+        end
+
+        private
+          attr_reader :db_config, :db_configuration_hash
+
+          def get_database_path(db_config)
+            if db_config.respond_to?(:database_path) && db_config.database_path
+              db_config.database_path
+            else
+              db_config.database
+            end
+          end
+      end
+    end
+  end
+end

--- a/lib/active_record/tenanted/database_configurations/base_config.rb
+++ b/lib/active_record/tenanted/database_configurations/base_config.rb
@@ -36,17 +36,9 @@ module ActiveRecord
         end
 
         def tenants
-          glob = database_path_for("*")
-          scanner = Regexp.new(database_path_for("(.+)"))
-
-          Dir.glob(glob).map do |path|
-            result = path.scan(scanner).flatten.first
-            if result.nil?
-              warn "WARN: ActiveRecord::Tenanted: Cannot parse tenant name from filename #{path.inspect}. " \
-                   "This is a bug, please report it to https://github.com/basecamp/activerecord-tenanted/issues"
-            end
-            result
-          end
+          ActiveRecord::Tenanted::DatabaseAdapter.list_tenant_databases(self)
+        rescue
+          []
         end
 
         def new_tenant_config(tenant_name)
@@ -85,9 +77,7 @@ module ActiveRecord
           end
 
           def validate_tenant_name(tenant_name)
-            if tenant_name.match?(%r{[/'"`]})
-              raise BadTenantNameError, "Tenant name contains an invalid character: #{tenant_name.inspect}"
-            end
+            ActiveRecord::Tenanted::DatabaseAdapter.validate_tenant_name(self, tenant_name)
           end
 
           def test_worker_path(path)

--- a/lib/active_record/tenanted/database_tasks.rb
+++ b/lib/active_record/tenanted/database_tasks.rb
@@ -27,11 +27,9 @@ module ActiveRecord
         raise ArgumentError, "Could not find a tenanted database" unless root_config = root_database_config
 
         root_config.tenants.each do |tenant|
-          # NOTE: This is obviously a sqlite-specific implementation.
-          # TODO: Create a `drop_database` method upstream in the sqlite3 adapter, and call it.
-          #       Then this would delegate to the adapter and become adapter-agnostic.
           root_config.database_path_for(tenant).tap do |path|
-            FileUtils.rm(path)
+            db_config = root_config.new_tenant_config(tenant)
+            ActiveRecord::Tenanted::DatabaseAdapter.drop_database(db_config)
             $stdout.puts "Dropped database '#{path}'" if verbose?
           end
         end

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -99,10 +99,8 @@ module ActiveRecord
         end
 
         def tenant_exist?(tenant_name)
-          # this will have to be an adapter-specific implementation if we support other than sqlite
-          database_path = tenanted_root_config.database_path_for(tenant_name)
-
-          File.exist?(database_path) && !ActiveRecord::Tenanted::Mutex::Ready.locked?(database_path)
+          db_config = tenanted_root_config.new_tenant_config(tenant_name)
+          ActiveRecord::Tenanted::DatabaseAdapter.database_exists?(db_config)
         end
 
         def with_tenant(tenant_name, prohibit_shard_swapping: true, &block)
@@ -121,14 +119,12 @@ module ActiveRecord
 
         def create_tenant(tenant_name, if_not_exists: false, &block)
           created_db = false
-          database_path = tenanted_root_config.database_path_for(tenant_name)
+          db_config = tenanted_root_config.new_tenant_config(tenant_name)
 
-          ActiveRecord::Tenanted::Mutex::Ready.lock(database_path) do
-            unless File.exist?(database_path)
-              # NOTE: This is obviously a sqlite-specific implementation.
-              # TODO: Add a `create_database` method upstream in the sqlite3 adapter, and call it.
-              #       Then this would delegate to the adapter and become adapter-agnostic.
-              FileUtils.touch(database_path)
+          ActiveRecord::Tenanted::DatabaseAdapter.acquire_lock(db_config, "create_#{tenant_name}") do
+            unless ActiveRecord::Tenanted::DatabaseAdapter.database_exists?(db_config)
+
+              ActiveRecord::Tenanted::DatabaseAdapter.create_database(db_config)
 
               with_tenant(tenant_name) do
                 connection_pool(schema_version_check: false)
@@ -138,7 +134,7 @@ module ActiveRecord
               created_db = true
             end
           rescue
-            FileUtils.rm_f(database_path)
+            ActiveRecord::Tenanted::DatabaseAdapter.drop_database(db_config)
             raise
           end
 
@@ -158,10 +154,8 @@ module ActiveRecord
             end
           end
 
-          # NOTE: This is obviously a sqlite-specific implementation.
-          # TODO: Create a `drop_database` method upstream in the sqlite3 adapter, and call it.
-          #       Then this would delegate to the adapter and become adapter-agnostic.
-          FileUtils.rm_f(tenanted_root_config.database_path_for(tenant_name))
+          db_config = tenanted_root_config.new_tenant_config(tenant_name)
+          ActiveRecord::Tenanted::DatabaseAdapter.drop_database(db_config)
         end
 
         def tenants
@@ -211,12 +205,12 @@ module ActiveRecord
           return superclass._create_tenanted_pool unless connection_class?
 
           tenant = current_tenant
-          unless File.exist?(tenanted_root_config.database_path_for(tenant))
-            raise TenantDoesNotExistError, "The database file for tenant #{tenant.inspect} does not exist."
-          end
+          db_config = tenanted_root_config.new_tenant_config(tenant)
 
-          config = tenanted_root_config.new_tenant_config(tenant)
-          pool = establish_connection(config)
+          unless ActiveRecord::Tenanted::DatabaseAdapter.database_exists?(db_config)
+            raise TenantDoesNotExistError, "The database for tenant #{tenant.inspect} does not exist."
+          end
+          pool = establish_connection(db_config)
 
           if schema_version_check
             pending_migrations = pool.migration_context.open.pending_migrations

--- a/test/unit/database_adapter_test.rb
+++ b/test/unit/database_adapter_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe ActiveRecord::Tenanted::DatabaseAdapter do
+  let(:sqlite_config) { create_config("sqlite3", "test.sqlite3") }
+
+  describe ".adapter_for" do
+    test "selects correct adapter for sqlite3" do
+      adapter = ActiveRecord::Tenanted::DatabaseAdapter.adapter_for(sqlite_config)
+      assert_instance_of ActiveRecord::Tenanted::DatabaseAdapters::SQLite, adapter
+    end
+
+    test "raises error for unsupported adapter" do
+      unsupported_config = create_config("mongodb", "test_db")
+
+      error = assert_raises ActiveRecord::Tenanted::Error do
+        ActiveRecord::Tenanted::DatabaseAdapter.adapter_for(unsupported_config)
+      end
+
+      assert_includes error.message, "Unsupported database adapter for tenanting: mongodb. Supported adapters: sqlite3"
+    end
+  end
+
+  describe "delegation" do
+    test ".create_database calls SQLite#create_database" do
+      sqlite_mock = Minitest::Mock.new
+      sqlite_mock.expect(:create_database, nil)
+
+      ActiveRecord::Tenanted::DatabaseAdapters::SQLite.stub(:new, sqlite_mock) do
+        ActiveRecord::Tenanted::DatabaseAdapter.create_database(sqlite_config)
+      end
+
+      assert_mock sqlite_mock
+    end
+
+    test ".drop_database calls SQLite#drop_database" do
+      sqlite_mock = Minitest::Mock.new
+      sqlite_mock.expect(:drop_database, nil)
+
+      ActiveRecord::Tenanted::DatabaseAdapters::SQLite.stub(:new, sqlite_mock) do
+        ActiveRecord::Tenanted::DatabaseAdapter.drop_database(sqlite_config)
+      end
+
+      assert_mock sqlite_mock
+    end
+
+    test ".database_exists? calls SQLite#database_exists?" do
+      sqlite_mock = Minitest::Mock.new
+      sqlite_mock.expect(:database_exists?, true)
+
+      result = ActiveRecord::Tenanted::DatabaseAdapters::SQLite.stub(:new, sqlite_mock) do
+        ActiveRecord::Tenanted::DatabaseAdapter.database_exists?(sqlite_config)
+      end
+
+      assert_equal true, result
+      assert_mock sqlite_mock
+    end
+
+    test ".list_tenant_databases calls SQLite#list_tenant_databases" do
+      sqlite_mock = Minitest::Mock.new
+      sqlite_mock.expect(:list_tenant_databases, [ "a", "b" ])
+
+      result = ActiveRecord::Tenanted::DatabaseAdapters::SQLite.stub(:new, sqlite_mock) do
+        ActiveRecord::Tenanted::DatabaseAdapter.list_tenant_databases(sqlite_config)
+      end
+
+      assert_equal [ "a", "b" ], result
+      assert_mock sqlite_mock
+    end
+
+    test ".validate_tenant_name calls SQLite#validate_tenant_name" do
+      sqlite_mock = Minitest::Mock.new
+      sqlite_mock.expect(:validate_tenant_name, nil, [ "tenant1" ])
+
+      ActiveRecord::Tenanted::DatabaseAdapters::SQLite.stub(:new, sqlite_mock) do
+        ActiveRecord::Tenanted::DatabaseAdapter.validate_tenant_name(sqlite_config, "tenant1")
+      end
+
+      assert_mock sqlite_mock
+    end
+
+    test ".acquire_lock (new signature) calls SQLite#acquire_lock" do
+      lock_name = "tenant_creation_test.sqlite3"
+      sqlite_mock = Minitest::Mock.new
+      sqlite_mock.expect(:acquire_lock, nil, [ lock_name ])
+
+      ActiveRecord::Tenanted::DatabaseAdapters::SQLite.stub(:new, sqlite_mock) do
+        ActiveRecord::Tenanted::DatabaseAdapter.acquire_lock(sqlite_config, lock_name) { }
+      end
+
+      assert_mock sqlite_mock
+    end
+
+    test ".acquire_lock (legacy signature) calls SQLite.acquire_lock (class)" do
+      identifier = "legacy_lock_id"
+
+      called = nil
+      klass = ActiveRecord::Tenanted::DatabaseAdapters::SQLite
+      existed = klass.respond_to?(:acquire_lock)
+      klass.singleton_class.class_eval { define_method(:acquire_lock) { |*args, **kwargs| } } unless existed
+
+      klass.stub(:acquire_lock, ->(id, &blk) { called = id; blk&.call }) do
+        ActiveRecord::Tenanted::DatabaseAdapter.acquire_lock(identifier) { :ok }
+      end
+
+      assert_equal identifier, called
+    ensure
+      klass.singleton_class.send(:remove_method, :acquire_lock) unless existed
+    end
+
+    test ".acquire_lock (new signature, non-sqlite) yields without calling adapter" do
+      non_sqlite_config = create_config("postgresql", "db_name")
+
+      yielded = false
+      ActiveRecord::Tenanted::DatabaseAdapter.acquire_lock(non_sqlite_config, "ignored") { yielded = true }
+
+      assert_equal true, yielded
+    end
+  end
+
+
+  private
+    def create_config(adapter, database)
+      config_hash = {
+        adapter: adapter,
+        database: database,
+      }
+
+      ActiveRecord::DatabaseConfigurations::HashConfig.new(
+        "test",
+        "test_config",
+        config_hash
+      )
+    end
+end

--- a/test/unit/database_tasks_test.rb
+++ b/test/unit/database_tasks_test.rb
@@ -14,10 +14,7 @@ describe ActiveRecord::Tenanted::DatabaseTasks do
   describe ".migrate_tenant" do
     for_each_scenario do
       setup do
-        # TODO: This should really be a create_database method on the sqlite3 adapter, see the notes
-        #       in Tenant.create_tenant.
-        FileUtils.mkdir_p(File.dirname(tenanted_config.database_path_for("foo")))
-        FileUtils.touch(tenanted_config.database_path_for("foo"))
+        ActiveRecord::Tenanted::DatabaseAdapter.create_database(tenanted_config.new_tenant_config("foo"))
       end
 
       test "database should be created" do


### PR DESCRIPTION
This extracts anything SQLite-specific into a generic database adapter class which forwards to a SQLite adapter class. This is a new pattern that will make it pretty easy to support different databases (I've got MySQL working in a different branch). Since this is a big change I wanted to validate the approach first and get this merged in for SQLite. But adding support for MYSql is fairly trivial after this change.

There should be no actual changes from the current implementation for SQLite—except for one place when we drop the db (I've added a comment at that line of code).

This pattern is very similar to how Rails does it. In Rails there's the main [ActiveRecord::Tasks::DatabaseTasks](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/tasks/database_tasks.rb) which defines the API and then forwards the implementation over to the specific adapter to do the work. For example here's the class for [SQLite](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb).

Originally I tried tackling this by using the adapters / methods that are provided by Rails but...it's just slightly different enough that it won't work as is. I think there's a world where we could upstream a bunch of these changes to into Rails and make it more compatible and/or make this gem more compatible for how Rails does it. Either way I thought it best to just do our own thing for now and cross that bridge another day. 😊

## How I tested
I relied on the test suite for this one and extracted everything without breaking any tests. I also added tests for the adapter to ensure that it forwards everything over to the correct adapter methods. I didn't unit test the actual SQLite adapter since this is well covered by other tests but I would be happy to add those as well.
